### PR TITLE
Use localtime_s on Windows (required by new toolchain)

### DIFF
--- a/src/geometry/base/logging.cc
+++ b/src/geometry/base/logging.cc
@@ -29,7 +29,11 @@ char* const DateLogger::HumanDate() {
 #else
   time_t time_value = time(NULL);
   struct tm now;
+#ifdef _WIN32
+  localtime_s(&now, &time_value);
+#else
   localtime_r(&time_value, &now);
+#endif
   snprintf(buffer_, sizeof(buffer_), "%02d:%02d:%02d",
            now.tm_hour, now.tm_min, now.tm_sec);
 #endif


### PR DESCRIPTION
The new toolchain requires that you use the windows specific `localtime_s` api. 

Can you please submit this to CRAN when submission re-opens next week? https://cran.r-project.org/submit.html